### PR TITLE
Update alignToMeth.cpp

### DIFF
--- a/src/alignToMeth.cpp
+++ b/src/alignToMeth.cpp
@@ -27,7 +27,7 @@ int byread(BamTools::BamAlignment al,
         al.GetTag("XM:Z:", Meth);
         std::string strand="+";
         if (al.IsReverseStrand()) {
-            std::reverse(Meth.begin(), Meth.end());
+            // std::reverse(Meth.begin(), Meth.end());
             strand="-";
         }
         for (int i = 0; i < al.QueryBases.size(); i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, const char * argv[])
         //default distance cutoff: 72 // trying to match seq length
         int d=72;
         //default read coverage: 60 
-        int cov=60;
+        int cov=10;
         
         std::cerr << "Default program paramters for methclone: \nMax loci width: " << d << " bp" << std::endl;
         std::cerr << "Min methylation difference cutoff: " << m << "%" << std::endl;


### PR DESCRIPTION
fix error on reading patterns on the reverse strand. 
The XM tag is coded based on CG content on reverse strand, but the order of the string is based on 5' to 3'.
Fixes #4 